### PR TITLE
Fixed build issue with analyzers 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -140,7 +140,7 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 # IDE0073: File header
 dotnet_diagnostic.IDE0073.severity = warning
-file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
+file_header_template = Copyright (c) Microsoft Corporation.\n Licensed under the MIT license.
 
 # CSharp code style settings:
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,7 +15,7 @@ on:
     types: [published]
 
 env:
-  DOTNET_VERSION: '3.1.200'
+  DOTNET_VERSION: '5.0.x'
   OUTPUT_DIR: 'dist'
   BUILD_TYPE: 'Release'
   NUGET_SOURCE_NAME: 'AzureIntegrationMigration'

--- a/nuget.config
+++ b/nuget.config
@@ -3,7 +3,6 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />    
   </packageSources>
 </configuration>

--- a/src/Microsoft.AzureIntegrationMigration.Runner/Microsoft.AzureIntegrationMigration.Runner.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.Runner/Microsoft.AzureIntegrationMigration.Runner.csproj
@@ -14,6 +14,8 @@
     <Version>0.0.4-alpha</Version>
     <NoWarn>NU5105</NoWarn>
     <AssemblyName>Microsoft.AzureIntegrationMigration.Runner</AssemblyName>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -26,14 +28,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />

--- a/tests/Microsoft.AzureIntegrationMigration.Runner.Tests/GlobalSuppressions.cs
+++ b/tests/Microsoft.AzureIntegrationMigration.Runner.Tests/GlobalSuppressions.cs
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 // This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given

--- a/tests/Microsoft.AzureIntegrationMigration.Runner.Tests/Microsoft.AzureIntegrationMigration.Runner.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Runner.Tests/Microsoft.AzureIntegrationMigration.Runner.Tests.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <AssemblyName>Microsoft.AzureIntegrationMigration.Runner.Tests</AssemblyName>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -24,14 +24,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="ILogger.Moq" Version="1.1.8" />

--- a/tests/Microsoft.AzureIntegrationMigration.Runner.Tests/Microsoft.AzureIntegrationMigration.Runner.Tests.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Runner.Tests/Microsoft.AzureIntegrationMigration.Runner.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.AzureIntegrationMigration.Runner.Tests</AssemblyName>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>

--- a/tests/Microsoft.AzureIntegrationMigration.Runner.Tests/RunnerExceptionFeature.cs
+++ b/tests/Microsoft.AzureIntegrationMigration.Runner.Tests/RunnerExceptionFeature.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using System;
 using System.IO;
@@ -136,6 +136,7 @@ namespace Microsoft.AzureIntegrationMigration.Runner.Tests
         /// <param name="e">The runner exception, if any.</param>
         [Scenario]
         [Trait(TestConstants.TraitCategory, TestConstants.CategoryUnitTest)]
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
         public void ConstructWithSerializationSuccess(RunnerException rex, IFormatter formatter, MemoryStream stream, Exception e)
         {
             "Given the runner exception"
@@ -163,6 +164,7 @@ namespace Microsoft.AzureIntegrationMigration.Runner.Tests
             "And the exception should have our custom message"
                 .x(() => rex.Message.Should().Be("an error message"));
         }
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
 
         #endregion
     }


### PR DESCRIPTION
## Description
Upgraded to .net 5 to use the analyzers which come with the SDK.
Removed the beta Rosyln analyzers and references to the nuget repo.
Fixed issues flagged by Code Analysis and updated the expected header template.

## Checklist
- [ ] Only increment the version number following a GitHub Release.  Check this only if this PR is a version bump.